### PR TITLE
Added missing modus condition in function is_modus_heating

### DIFF
--- a/components/daikin_rotex_can/daikin_rotex_can.cpp
+++ b/components/daikin_rotex_can/daikin_rotex_can.cpp
@@ -536,7 +536,7 @@ bool DaikinRotexCanComponent::is_command_set(TMessage const& message) {
 }
 
 bool DaikinRotexCanComponent::is_modus_heating(std::string const& modus) {
-    return modus == Translation::T_HEATING || modus == Translation::T_AUTOMATIC_1 || modus == Translation::T_AUTOMATIC_2;
+    return modus == Translation::T_HEATING || modus == Translation::T_LOWERING || modus == Translation::T_AUTOMATIC_1 || modus == Translation::T_AUTOMATIC_2;
 }
 
 std::string DaikinRotexCanComponent::recalculate_state(EntityBase* pEntity, std::string const& new_state) {


### PR DESCRIPTION
Added missing condition T_ LOWERING. In case ROTEX is in REDUCED mode Optimized Defrosting is not working.