### PR TITLE
Improve COP calculation logic in Berechnung COP.yaml to remove spikes.

### DIFF
--- a/templates/Berechnung COP.yaml
+++ b/templates/Berechnung COP.yaml
@@ -9,12 +9,12 @@ sensor:
           {% set stromverbrauch = states('sensor.wp_channel_a_power') | float(0) / 1000 %}
           {% set kompressor_status = states('sensor.rotex_status_kompressor') %}
           
-          {% if kompressor_status == 'An' and stromverbrauch > 0 %}
-            {% if thermische_leistung >= 0 %}
-              {{ (thermische_leistung / stromverbrauch) | round(2) }}
-            {% else %}
-              {{ (-1 * thermische_leistung / stromverbrauch) | round(2) }}
+          {% if kompressor_status == 'An' and states('sensor.hpsu_can_flow_rate')|int >300 and stromverbrauch > 0.15 %} # 0.15 Ajust to any resonable power grather than 0
+            {% set cop = (thermische_leistung / stromverbrauch) | abs | round(2) %} # abs conversts negative to positive
+            {% if cop > 10 %} # set cop =0 if cop is still overshooted
+              {%set cop = 0 %}
             {% endif %}
+            {{ cop }}
           {% else %}
             0  # Wenn der Kompressor nicht läuft, wird COP auf 0 gesetzt
           {% endif %}


### PR DESCRIPTION
Refactor COP calculation to handle negative values and add conditions for COP calculation.

To remove negative values in COP added abs function, to minimise lines. Safety checks:
*  If power >150W else it is a noise in COP calculation.
*  Added flow_rate sensor> 300L/h as addition to compresor_status. Some times it shows compressor still on, but flow rate is already 0.
 *  If COP is still overshoot as high as >10, replace with 0.

150W and 300L/h it is just a numbers that seems to be reasonable for me, they can be adjusted.

(* Sorry it is in english. *)