### PR TITLE
fix: add missing #include <deque> in entity_manager.h

### DIFF
--- a/components/daikin_rotex_can/entity_manager.h
+++ b/components/daikin_rotex_can/entity_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <deque>
 #include "esphome/components/daikin_rotex_can/sensors.h"
 #include "esphome/components/daikin_rotex_can/entity.h"
 


### PR DESCRIPTION
fix for: https://github.com/Trunks1982/Daikin-Rotex-HPSU-CAN-Seriell/issues/141

CoPilot:

> In ESPHome 2026.3.0 wurden offenbar einige transitive Header-Includes entfernt, sodass `[<deque>]` nicht mehr implizit eingebunden wird. Der explizite Include behebt den Kompilierfehler.