### PR TITLE
fix: replace std::regex for ESPHome 2026.4.0 compatibility

### DIFF
--- a/components/daikin_rotex_can/daikin_rotex_can.cpp
+++ b/components/daikin_rotex_can/daikin_rotex_can.cpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 #include <limits>
-#include <regex>
 
 namespace esphome {
 namespace daikin_rotex_can {
@@ -354,18 +353,36 @@ void DaikinRotexCanComponent::on_betriebsmodus(TEntity::TVariant const& current,
     }
 }
 
+// Validates a string of 1-7 hex bytes like "0x31 0xAB 0x0F" or "31 AB 0F"
+static bool is_valid_hex_bytes(const std::string& s) {
+    if (s.empty()) return false;
+    std::istringstream iss(s);
+    std::string token;
+    int count = 0;
+    while (iss >> token) {
+        if (++count > 7) return false;
+        size_t offset = 0;
+        if (token.size() >= 2 && token[0] == '0' && (token[1] == 'x' || token[1] == 'X')) {
+            offset = 2;
+        }
+        if (token.size() - offset != 2) return false;
+        for (size_t i = offset; i < token.size(); ++i) {
+            if (!std::isxdigit(static_cast<unsigned char>(token[i]))) return false;
+        }
+    }
+    return count >= 1;
+}
+
 ///////////////// Texts /////////////////
 void DaikinRotexCanComponent::custom_request(std::string const& value) {
-    std::regex pattern(R"(^((?:0x[0-9A-Fa-f]{2}|[0-9A-Fa-f]{2})(?:\s(?:0x[0-9A-Fa-f]{2}|[0-9A-Fa-f]{2})){0,6})$)");
-    std::smatch match;
-    if (std::regex_match(value, match, pattern)) {
+    if (is_valid_hex_bytes(value)) {
         uint16_t can_id = 0x680;
         const bool use_extended_id = false;
 
-        const TMessage message = Utils::str_to_bytes(match[1].str());
+        const TMessage message = Utils::str_to_bytes(value);
 
         Utils::log(TAG, "custom_request() can_id<%s> data<%s> str<%s>",
-            Utils::to_hex(can_id).c_str(), Utils::to_hex(message).c_str(), match[1].str().c_str());
+            Utils::to_hex(can_id).c_str(), Utils::to_hex(message).c_str(), value.c_str());
 
         esphome::esp32_can::ESP32Can* pCanbus = m_entity_manager.getCanbus();
         pCanbus->send_data(can_id, use_extended_id, { message.begin(), message.end() });

--- a/components/daikin_rotex_can/utils.cpp
+++ b/components/daikin_rotex_can/utils.cpp
@@ -2,7 +2,6 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include <iomanip>
-#include <regex>
 
 namespace esphome {
 namespace daikin_rotex_can {
@@ -75,8 +74,31 @@ TMessage Utils::str_to_bytes(const std::string& str) {
 TMessage Utils::str_to_bytes_array8(const std::string& str) {
     TMessage byte_array{};
 
-    std::string cleaned_str = std::regex_replace(str, std::regex("[^0-9A-Fa-f\\s]+"), "");
-    cleaned_str = std::regex_replace(cleaned_str, std::regex("\\s+"), " ");
+    // Remove non-hex, non-whitespace characters
+    std::string cleaned_str;
+    for (char c : str) {
+        if (std::isxdigit(static_cast<unsigned char>(c)) || std::isspace(static_cast<unsigned char>(c))) {
+            cleaned_str += c;
+        }
+    }
+    // Collapse consecutive whitespace into single spaces and trim
+    std::string collapsed;
+    bool last_was_space = true;
+    for (char c : cleaned_str) {
+        if (std::isspace(static_cast<unsigned char>(c))) {
+            if (!last_was_space) {
+                collapsed += ' ';
+                last_was_space = true;
+            }
+        } else {
+            collapsed += c;
+            last_was_space = false;
+        }
+    }
+    if (!collapsed.empty() && collapsed.back() == ' ') {
+        collapsed.pop_back();
+    }
+    cleaned_str = collapsed;
 
     std::stringstream ss(cleaned_str);
     std::string byte_str;


### PR DESCRIPTION
## Problem

ESPHome 2026.4.0 updated to pioarduino 55.03.38 with GCC 14.2.0 toolchain ([esphome/esphome#15666](https://github.com/esphome/esphome/pull/15666)). The new toolchain ships `libstdc++` without RTTI, causing linker errors when using `std::regex`:

```
undefined reference to `typeinfo for std::ctype<char>'
undefined reference to `typeinfo for std::locale::facet'
```

## Solution

Replace all `std::regex` usage with manual string processing:

- **`utils.cpp`**: Replace `std::regex_replace` in `str_to_bytes_array8()` with manual character filtering (keep only hex digits and whitespace) and whitespace normalization
- **`daikin_rotex_can.cpp`**: Replace `std::regex_match` in `custom_request()` with a new `is_valid_hex_bytes()` helper function that validates 1-7 hex bytes (`0xHH` or `HH`, space-separated)
- Remove `#include <regex>` from both files

Functionality remains identical, but without the RTTI dependency.