### PR TITLE
Fix -Wformat warnings in logging and Utils::to_hex

### DIFF
--- a/components/daikin_rotex_can/daikin_rotex_can.cpp
+++ b/components/daikin_rotex_can/daikin_rotex_can.cpp
@@ -632,7 +632,7 @@ std::string DaikinRotexCanComponent::recalculate_state(EntityBase* pEntity, std:
         if (p_betriebs_art != nullptr && flow_rate != nullptr && dhw_mixer_position != nullptr && state_compressor != nullptr && tdhw1 != nullptr) {
             const bool is_error_state = p_betriebs_art->state == Translation::T_HOT_WATER_PRODUCTION && tdhw1->state < 48.0 && (flow_rate->state == 0.0f || dhw_mixer_position->state == 0.0f || !state_compressor->state);
             if (m_dhw_error_detection.handle_error_detection(is_error_state)) {
-                ESP_LOGE(TAG, "DHW error => flow: %d, mixer_pos: %d, state_compressor: %d", flow_rate->state, dhw_mixer_position->state, state_compressor->state);
+                ESP_LOGE(TAG, "DHW error => flow: %f, mixer_pos: %f, state_compressor: %d", flow_rate->state, dhw_mixer_position->state, state_compressor->state);
                 return new_state + "|" + Translation::T_MISSING_FLOW;
             }
         }

--- a/components/daikin_rotex_can/utils.cpp
+++ b/components/daikin_rotex_can/utils.cpp
@@ -35,7 +35,7 @@ std::vector<std::string> Utils::split(std::string const& str) {
 
 std::string Utils::to_hex(uint32_t value) {
     char hex_string[20];
-    sprintf(hex_string, "0x%02X", value);
+    sprintf(hex_string, "0x%02lX", static_cast<unsigned long>(value));
     return std::string(hex_string);
 }
 


### PR DESCRIPTION
The ESP-IDF build emits -Wformat warnings in two places of the daikin_rotex_can component. This PR fixes both without changing any runtime behaviour.

### Changes
**components/daikin_rotex_can/daikin_rotex_can.cpp**
In the DHW error log, flow_rate->state and dhw_mixer_position->state are float values (promoted to double by the variadic call), but were formatted with %d (integer). Corrected to %f. state_compressor->state is a bool and correctly stays %d.

```C++
// before
ESP_LOGE(TAG, "DHW error => flow: %d, mixer_pos: %d, state_compressor: %d",
         flow_rate->state, dhw_mixer_position->state, state_compressor->state);

// after
ESP_LOGE(TAG, "DHW error => flow: %f, mixer_pos: %f, state_compressor: %d",
         flow_rate->state, dhw_mixer_position->state, state_compressor->state);
```
**components/daikin_rotex_can/utils.cpp**
Utils::to_hex(uint32_t) passed a uint32_t with %X. On the ESP32 target unsigned int and unsigned long have the same size, but the compiler correctly warns because the types differ in the format string. Fixed by using %02lX together with an explicit static_cast<unsigned long>. Output is identical.

```C++
// before
sprintf(hex_string, "0x%02X", value);

// after
sprintf(hex_string, "0x%02lX", static_cast<unsigned long>(value));
```
### Impact
No functional or behavioural change.
Eliminates compiler warnings, keeping the build clean on ESP-IDF / ESPHome 2026.7.0+.